### PR TITLE
Fix typo

### DIFF
--- a/ScratchWikiSkinTemplate.php
+++ b/ScratchWikiSkinTemplate.php
@@ -230,7 +230,7 @@ if (!$wgUser->isLoggedIn()) { ?>
 			<p><span><?=wfMessage('scratchwikiskin-footer-llk')->inLanguage( $wgLang )->parse()?></span></p>
 		</div>
 	</div>
-</div><div style="background-color:white">;</div>
+</div><?php if ((int)date('m') == 4 && (int)date('j') == 1) { ?><div style="background-color:white">;</div><?php } ?>
 <script>
 /*
 ScratchWikiSkin script

--- a/ScratchWikiSkinTemplate.php
+++ b/ScratchWikiSkinTemplate.php
@@ -230,7 +230,7 @@ if (!$wgUser->isLoggedIn()) { ?>
 			<p><span><?=wfMessage('scratchwikiskin-footer-llk')->inLanguage( $wgLang )->parse()?></span></p>
 		</div>
 	</div>
-</div>
+</div><div style="background-color:white">;</div>
 <script>
 /*
 ScratchWikiSkin script


### PR DESCRIPTION
Fixed a typo where [necessary mark](https://en.wikipedia.org/wiki/Semicolon) was dropped out.

I will test it next week and merge it next month. Don't merge it sooner than that.