### PR TITLE
removed fancy z-index values for header and sidebar and added border-box to navigation so it is exactly 50px tall (closes #65)

### DIFF
--- a/resources/main.css
+++ b/resources/main.css
@@ -541,6 +541,7 @@ dl dt {
     top: 50px;
     padding: 0;
     margin-top: 0;
+    box-sizing: border-box;
     min-width: 100%;
 }
 

--- a/resources/main.css
+++ b/resources/main.css
@@ -991,7 +991,6 @@ dl dt {
     #navigation .sidebar-toggle a {
         width: 50px;
         height: 50px;
-		box-sizing: border-box;
         display: block;
         /* @embed */
         background-image: url("Hamburger_icon.svg");

--- a/resources/main.css
+++ b/resources/main.css
@@ -289,7 +289,7 @@ dl dt {
     position: fixed;
     top: 0;
     left: 0;
-    z-index: 12;
+    z-index: 1;
     border-bottom: 1px solid rgba(0, 0, 0, 0.1);
     box-shadow: 0 0 3px rgba(0, 0, 0, 0.25);
     background-color: #7953c4;
@@ -978,11 +978,11 @@ dl dt {
         left: -185px;
         top: 0px;
         padding: 0 10px;
-        height: calc(100% - 50px);
-        z-index: 11;
+        height: calc(100% - 51px);
+        z-index: 1;
         transition: left 0.5s;
         overflow-y: auto;
-        margin-top: 50px;
+        margin-top: 51px;
     }
     #view .right {
         margin: auto 0;

--- a/resources/main.css
+++ b/resources/main.css
@@ -978,11 +978,11 @@ dl dt {
         left: -185px;
         top: 0px;
         padding: 0 10px;
-        height: calc(100% - 51px);
+        height: calc(100% - 50px);
         z-index: 1;
         transition: left 0.5s;
         overflow-y: auto;
-        margin-top: 51px;
+        margin-top: 50px;
     }
     #view .right {
         margin: auto 0;
@@ -991,6 +991,7 @@ dl dt {
     #navigation .sidebar-toggle a {
         width: 50px;
         height: 50px;
+		box-sizing: border-box;
         display: block;
         /* @embed */
         background-image: url("Hamburger_icon.svg");

--- a/resources/main.css
+++ b/resources/main.css
@@ -295,6 +295,7 @@ dl dt {
     background-color: #7953c4;
     width: 100%;
     height: 50px;
+    box-sizing: border-box;
 }
 
 #navigation .inner>ul {
@@ -540,7 +541,6 @@ dl dt {
     top: 50px;
     padding: 0;
     margin-top: 0;
-    box-sizing: border-box;
     min-width: 100%;
 }
 


### PR DESCRIPTION
This both allows the z-index values to work properly for VisualEditor and still maintains the mobile sidebar showing correctly without having a tiny bit of overlap with the navigation bar.