### PR TITLE
Fix edit pencil image

### DIFF
--- a/ScratchWikiSkinTemplate.php
+++ b/ScratchWikiSkinTemplate.php
@@ -75,9 +75,7 @@ class ScratchWikiSkinTemplate extends BaseTemplate {
 				</form>
 			</li>
 			<li class="link right content-actions">
-				<a class="dropdown-toggle" href="?action=edit">
-					<img src="<?=$wgStylePath?>/ScratchWikiSkin2/resources/Edit-pencil.png" width="25" height="25" />
-				</a>
+				<a class="dropdown-toggle" href="?action=edit"></a>
 				<ul class="dropdown">
 <?php foreach ($this->data['content_actions'] as $key => $tab) { ?>
 					<?=$this->makeListItem($key, $tab)?>

--- a/ScratchWikiSkinTemplate.php
+++ b/ScratchWikiSkinTemplate.php
@@ -75,7 +75,7 @@ class ScratchWikiSkinTemplate extends BaseTemplate {
 				</form>
 			</li>
 			<li class="link right content-actions">
-				<a class="dropdown-toggle" href="?action=edit"></a>
+				<a class="dropdown-toggle" href="?action=edit"><div></div></a>
 				<ul class="dropdown">
 <?php foreach ($this->data['content_actions'] as $key => $tab) { ?>
 					<?=$this->makeListItem($key, $tab)?>

--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -682,8 +682,13 @@ dl dt {
 
 #navigation ul>li.content-actions>a.dropdown-toggle {
     height: 25px;
-    width: auto;
+    width: 25px;
     padding: 12.5px;
+    /* @embed */
+    background-image: url('../Edit-pencil.png');
+    background-size: 25px 25px;
+    background-position: center;
+    background-repeat: no-repeat;
 }
 
 #lastmod {

--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -682,13 +682,21 @@ dl dt {
 
 #navigation ul>li.content-actions>a.dropdown-toggle {
     height: 25px;
-    width: 25px;
+    width: auto;
+    min-width: 25px;
     padding: 12.5px;
     /* @embed */
     background-image: url('../Edit-pencil.png');
     background-size: 25px 25px;
-    background-position: center;
+    background-position: 12.5px center;
     background-repeat: no-repeat;
+}
+
+#navigation ul>li.content-actions>a.dropdown-toggle>div {
+    height: 25px;
+    width: 25px;
+    display: inline-block;
+    vertical-align: middle;
 }
 
 #lastmod {


### PR DESCRIPTION
Resolves #73 
Instead of hardcoding the image path, use ResourceLoader to embed the image data in the stylesheet directly as a background-image. (This doesn't work on browsers that don't support `data:` urls for background images, but that [should be almost no one](https://caniuse.com/?search=data%20urls).)