### PR TITLE
Use wgLogos['wordmark'] for sourcing stratchwiki logo

### DIFF
--- a/ScratchWikiSkinTemplate.php
+++ b/ScratchWikiSkinTemplate.php
@@ -21,11 +21,19 @@ class ScratchWikiSkinTemplate extends BaseTemplate {
 	background-color: <?=htmlspecialchars(str_replace([';', '}'], '', $wgUser->getOption( 'scratchwikiskin-header-color' )))?>;
 }
 </style>
+<?php
+$logos = ResourceLoaderSkinModule::getAvailableLogos( $this->getSkin()->getConfig() );
+$wordmark = $logos['wordmark']['src'] ?? 'https://scratch.mit.edu/images/logo_sm.png';
+$wordmarkW = $logos['wordmark']['width'] ?? 76;
+$wordmarkH = $logos['wordmark']['height'] ?? 28;
+?>
 <div id="navigation" role="banner">
 	<div class="inner">
 		<ul>
 			<li class="sidebar-toggle"><a></a></li>
-			<li class="logo"><a aria-label="Scratch" href="https://scratch.mit.edu/"></a></li>
+			<li class="logo"><a aria-label="Scratch" href="https://scratch.mit.edu/">
+				<img alt="<?=wfMessage('sitetitle')->inContentLanguage()->text()?>" src="<?=$wordmark ?>" height="<?= $wordmarkH ?>" width="<?= $wordmarkW ?>">
+			</a></li>
 			<li class="link create">
 				<a class="dropdown-toggle" href="https://scratch.mit.edu/projects/editor/"><span><?=wfMessage('scratchwikiskin-create')->inLanguage( $wgLang )->escaped()?></span></a>
 				<ul class="dropdown">

--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -367,16 +367,14 @@ dl dt {
 }
 
 #navigation .logo a {
-    background-size: 95%;
+    display: flex;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
 }
 
 #navigation .logo a {
-    background-image: url("https://scratch.mit.edu/images/logo_sm.png");
-    background-repeat: no-repeat;
-    background-position: center center;
     margin: 0 6px 0 0;
-    width: 81px;
-    height: 50px;
 }
 
 #navigation .logo a:hover,
@@ -384,8 +382,8 @@ dl dt {
     transition: .15s ease all;
 }
 
-#navigation .logo a:hover {
-    background-size: 100%;
+#navigation .logo a:hover img {
+    transform: scale(1.05, 1.05);
 }
 
 #navigation .content-actions .dropdown-toggle:hover {


### PR DESCRIPTION
This allows other 3rd parties the ability to assign a logo
as well as giving an easier way to control
the logo in the header for sysadmins.