### PR TITLE
Restrict skin header preference to when skin is selected

### DIFF
--- a/ScratchWikiSkin.skin.php
+++ b/ScratchWikiSkin.skin.php
@@ -72,6 +72,8 @@ class SkinScratchWikiSkin extends SkinTemplate {
 			'label-message' => 'scratchwikiskin-pref-color',
 			'section' => 'rendering/skin',
 			'default' => ($origpref ? $origpref : '#7953c4'),
+			// Only expose background color preference when the skin is selected
+			'hide-if' => [ '!==', 'wpskin', 'scratchwikiskin2' ],
 		];
 		return true;
 	}


### PR DESCRIPTION
When another skin is selected the appearance of the change header color
preference has no effect and is confusing

This change makes Scratchwiki consistent with Vector and Monobook by
only showing the skin preference when the skin has been selected.

Replication steps:
* Select Vector as skin in Special:Preferences
* Expected: the color changer does not show.
* Select ScratchWikiSkin2 as skin in Special:Preferences
* Expected: the color changer shows
* 


