### PR TITLE
Add Permissions-Policy header to disable FLoC

### DIFF
--- a/ScratchWikiSkin.skin.php
+++ b/ScratchWikiSkin.skin.php
@@ -63,6 +63,8 @@ class SkinScratchWikiSkin extends SkinTemplate {
 		] );
 		// make Chrome mobile testing work
 		$out->addMeta('viewport', 'user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width, height=device-height');
+		// optout FLoC
+		$out->getRequest()->response()->header('Permissions-Policy: interest-cohort=()');
 	}
 
 	static function onGetPreferences( $user, &$preferences ) {


### PR DESCRIPTION
Chrome is soon shipping FLoC to all websites that do not specify `Permissions-Policy: interest-cohort=()`. Visiting such websites could influence results of interest cohort calculation. This PR adds the header to prevent the browser from tracking the viewers that visit Scratch Wiki.