### PR TITLE
Avoid deprecation warnings in 1.39

### DIFF
--- a/ScratchWikiSkin.skin.php
+++ b/ScratchWikiSkin.skin.php
@@ -53,6 +53,14 @@ class SkinScratchWikiSkin extends SkinTemplate {
 		$template = 'ScratchWikiSkinTemplate', $useHeadElement = true;
 
 	/**
+	 * @inheritDoc
+	 */
+	public function __construct( $options ) {
+		$options['bodyOnly'] = true;
+		parent::__construct( $options );
+	}
+
+	/**
 	 * Add CSS via ResourceLoader
 	 *
 	 * @param OutputPage $out

--- a/ScratchWikiSkinTemplate.php
+++ b/ScratchWikiSkinTemplate.php
@@ -15,7 +15,11 @@ class ScratchWikiSkinTemplate extends BaseTemplate {
 		global $wgRequest, $wgStylePath, $wgLogo, $wgRightsPage, $wgRightsUrl, $wgRightsIcon, $wgRightsText, $wgLang, $wgSWS2JoinBox;
 		$user = RequestContext::getMain()->getUser();
 		$skin = $this->data['skin'];
-		$this->html('headelement');
+		$pre139 = version_compare( MW_VERSION, '1.39', '<' );
+
+		if ( $pre139 ) {
+			$this->html('headelement');
+		}
 		$userOptionsLookup = MediaWikiServices::getInstance()->getUserOptionsLookup();
 		$colorPref = $userOptionsLookup->getOption( $user, HEADER_COLOR_PREF );
 		$darkPref = $userOptionsLookup->getOption( $user, DARK_THEME_PREF );
@@ -354,6 +358,10 @@ document.querySelector('#navigation .sidebar-toggle').addEventListener('click', 
 });
 
 </script>
-<?php $this->printTrail();
+
+<?php
+		if ( $pre139 ) {
+			$this->printTrail();
+		}
 	}
 }


### PR DESCRIPTION
A change in 1.39 means skins should not output head, and html tags.
This change is backwards compatible so you can apply it now without
disruption in later MediaWiki versions.

See https://phabricator.wikimedia.org/T306942 for more information