### PR TITLE
Use CSS flex to arrange sidebar and content

### DIFF
--- a/resources/css/main.css
+++ b/resources/css/main.css
@@ -169,13 +169,10 @@ dl dt {
 }
 
 #view .left {
-    float: left;
     width: 160px;
-    display: block;
 }
 
 #view .right {
-    margin-left: 180px;
     width: 800px;
 }
 
@@ -739,6 +736,9 @@ dl dt {
 
 .inner.mod-splash {
     margin-top: 20px;
+    display: flex;
+    flex-direction: row;
+    gap: 20px;
 }
 
 .splash .box {


### PR DESCRIPTION
Fixes #126. `float: left` is broken on Safari 16 for some reason, and this is likely a more future-proof solution.

/cc @dominic-03, @GrahamSH-LLK, and @gohoski - please review if you can / have your own MediaWiki instance to test it on. If not, I have this PR on my test wiki: https://test-wiki.abyx.dev