### PR TITLE
Don't click messages icon when hovering to it from pencil menu

### DIFF
--- a/ScratchWikiSkinTemplate.php
+++ b/ScratchWikiSkinTemplate.php
@@ -328,7 +328,7 @@ var body = mod(document.body);
 				&& !document.querySelector('.suggestions')?.contains(e.toElement)
 			) {
 				if (btn.hasclass('open')) {
-					if (e.toElement.matches('#navigation .link, #navigation .link>a, #navigation .link>a *')) {
+					if (e.toElement.matches('#navigation .link:not([class~=messages]), #navigation .link>a.dropdown-toggle, #navigation .link>a.dropdown-toggle *')) {
 						e.toElement.click();
 					}
 				}


### PR DESCRIPTION
This specifies `.dropdown-toggle` links, but also special-cases an exclusion for the `.messages` link to be safe.

Fixes #132 