### PR TITLE
Fix ResourceLoader SkinModule name

### DIFF
--- a/ScratchWikiSkinTemplate.php
+++ b/ScratchWikiSkinTemplate.php
@@ -30,7 +30,7 @@ class ScratchWikiSkinTemplate extends BaseTemplate {
 }
 </style>
 <?php
-$logos = ResourceLoaderSkinModule::getAvailableLogos( $this->getSkin()->getConfig() );
+$logos = MediaWiki\ResourceLoader\SkinModule::getAvailableLogos( $this->getSkin()->getConfig() );
 $wordmark = $logos['wordmark']['src'] ?? $this->get('stylepath') . '/' . $this->getSkin()->stylename . '/resources/Scratch-logo-sm.png';
 $wordmarkW = $logos['wordmark']['width'] ?? 76;
 $wordmarkH = $logos['wordmark']['height'] ?? 28;

--- a/skin.json
+++ b/skin.json
@@ -29,7 +29,7 @@
 	},
 	"ResourceModules": {
 		"skins.scratchwikiskin2": {
-			"class": "ResourceLoaderSkinModule",
+			"class": "MediaWiki\\ResourceLoader\\SkinModule",
 			"features": {
 				"content-links": true,
 				"content-media": true,


### PR DESCRIPTION
Use `MediaWiki\ResourceLoader\SkinModule` instead of deprecated alias `ResourceLoaderSkinModule`

Fixes #134